### PR TITLE
change input type and prepend dir path to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ```
 nextflow run pl-mqc \
-    --bucket 's3://foo/bar' \
-    --mqc_config 'mqc_config.yml' \
-     -work-dir 's3://foo/bar' \
+    --input_file 's3://foo/bar' \
+    --config_mqc 'mqc_config.yml' \
+    -work-dir 's3://foo/bar' \
     --outdir 's3://foo/bar' \
     -resume
 ```

--- a/main.nf
+++ b/main.nf
@@ -28,13 +28,13 @@ process MULTIQC {
         aws s3 cp "$line" local_files/"$line" --recursive
     done < !{fileList}
 
-    find local_files -type f > local_file_list.txt
+    find local_files -mindepth 1 -maxdepth 1 -type d > local_file_list.txt
 
     multiqc --file-list local_file_list.txt \
         --data-dir \
         --data-format csv \
         --no-report \
-        --dirs-depth 6 \
+        --dirs-depth 8 \
         --force \
         -o multiqc_output
     mv multiqc_output/multiqc_data/* .

--- a/main.nf
+++ b/main.nf
@@ -31,7 +31,6 @@ process MULTIQC {
     find local_files -mindepth 1 -maxdepth 1 -type d > local_file_list.txt
 
     multiqc --file-list local_file_list.txt \
-        --data-dir \
         --data-format csv \
         --no-report \
         --dirs-depth 8 \

--- a/main.nf
+++ b/main.nf
@@ -34,7 +34,7 @@ process MULTIQC {
         --data-dir \
         --data-format csv \
         --no-report \
-        --dirs \
+        --dirs-depth 6 \
         --force \
         -o multiqc_output
     mv multiqc_output/multiqc_data/* .

--- a/main.nf
+++ b/main.nf
@@ -24,8 +24,8 @@ process MULTIQC {
 
     apt-get update && apt-get install -y awscli || yum install -y awscli
 
-    while IFS= read -r line; do
-        aws s3 cp "$line" local_files/"$line" --recursive
+    while IFS= read -r line; do d="${line%/}"; dir=${d##*/};
+        aws s3 cp "$line" local_files/"$dir" --recursive
     done < !{fileList}
 
     find local_files -mindepth 1 -maxdepth 1 -type d > local_file_list.txt


### PR DESCRIPTION
Input type changed to a list with s3 path. Example:

s3://bucket/mqc/$repoID_$runName
s3://bucket/mqc/$repoID2_$runName

For the output, full directory path will be in the 'Sample' column. Example:
/ | tmp | nxf.9CtFdP0cOs | local_files | s3: | bucket | mqc | $repoID_#runName | $repoID | $repoID