### PR TITLE
Refactor input to --file-list and prepend full directory path to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ```
 nextflow run pl-mqc \
-    --bucket 's3://foo/bar' \
-    --mqc_config 'mqc_config.yml' \
-     -work-dir 's3://foo/bar' \
+    --input_file 's3://foo/bar' \
+    --config_mqc 'mqc_config.yml' \
+    -work-dir 's3://foo/bar' \
     --outdir 's3://foo/bar' \
     -resume
 ```

--- a/main.nf
+++ b/main.nf
@@ -1,7 +1,8 @@
 nextflow.enable.dsl=2
 
 workflow {
-    MULTIQC(params.input_file, params.config_mqc, params.outdir)
+    Channel.fromPath("${params.dir_input}", type: 'dir').set { runDirectory }
+    MULTIQC(runDirectory, params.input_file, params.config_mqc, params.outdir)
 }
 
 process MULTIQC {
@@ -32,12 +33,20 @@ process MULTIQC {
     
     aws s3 cp local_file_list.txt s3://bgsi-data-dev/RT/multiqc/local_file_list.txt
     
-    multiqc --file-list local_file_list.txt \
+    // multiqc --file-list local_file_list.txt \
+    //     --data-format csv \
+    //     --no-report \
+    //     --dirs-depth 10 \
+    //     --force \
+    //     -o multiqc_output
+    multiqc ${config} \
+        --file-list local_file_list.txt \
+        --data-dir \
         --data-format csv \
         --no-report \
-        --dirs-depth 10 \
         --force \
         -o multiqc_output
+        ${runDirectory}
     mv multiqc_output/multiqc_data/* .
     '''
 }

--- a/main.nf
+++ b/main.nf
@@ -9,6 +9,7 @@ process MULTIQC {
     container 'biocontainers/multiqc:1.27.1--pyhdfd78af_0'
 
     input:
+    path runDirectory
     path fileList
     path multiqcConfig
     val outdir

--- a/main.nf
+++ b/main.nf
@@ -1,32 +1,43 @@
 nextflow.enable.dsl=2
 
 workflow {
-    Channel.fromPath("${params.dir_input}", type: 'dir').set { runDirectory }
-    MULTIQC(runDirectory, params.config_mqc)
+    MULTIQC(params.input_file, params.config_mqc, params.outdir)
 }
 
 process MULTIQC {
-    container 'biocontainers/multiqc:1.25--pyhdfd78af_0'
+    container 'biocontainers/multiqc:1.27.1--pyhdfd78af_0'
 
     input:
-    path runDirectory
+    path fileList
     path multiqcConfig
+    val outdir
 
     output:
     path("*")
 
     def isoDate = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    publishDir {"${params.outdir}" }, mode: params.publish_dir_mode, pattern: "multiqc_general_stats.csv", saveAs: { "${isoDate}.csv" }
+    publishDir {"${outdir}" }, mode: params.publish_dir_mode, pattern: "multiqc_general_stats.csv", saveAs: { "${isoDate}.csv" }
+
+    shell:
+    '''
+    mkdir -p local_files
+
+    apt-get update && apt-get install -y awscli || yum install -y awscli
+
+    while IFS= read -r line; do d="${line%/}"; dir=${d##*/};
+        aws s3 cp "$line" local_files/"$dir" --recursive
+    done < !{fileList}
+
+    find local_files -mindepth 1 -maxdepth 1 -type d > local_file_list.txt
     
-    script:
-    def config = multiqcConfig ? "--config $multiqcConfig" : ''
-    """
-    multiqc ${config} \
-        --data-dir \
+    aws s3 cp local_file_list.txt s3://bgsi-data-dev/RT/multiqc/local_file_list.txt
+    
+    multiqc --file-list local_file_list.txt \
         --data-format csv \
         --no-report \
+        --dirs-depth 10 \
         --force \
-        ${runDirectory}
-    mv multiqc_data/* .
-    """
+        -o multiqc_output
+    mv multiqc_output/multiqc_data/* .
+    '''
 }


### PR DESCRIPTION
Input parameter changed to a list with s3 path. Example:
$cat input_lists
s3://bucket/mqc/$repoID_$runName
s3://bucket/mqc/$repoID2_$runName

For the output, directory path will be in the 'Sample' column. Example:
/ | tmp | nxf.JUGetxOsPk | local_files | $repoID_$runName-$uuid | $repoID | $repoID