### PR TITLE
Refactor input to --file-list and prepend full directory path to output

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,32 +1,45 @@
 nextflow.enable.dsl=2
 
 workflow {
-    Channel.fromPath("${params.dir_input}", type: 'dir').set { runDirectory }
-    MULTIQC(runDirectory, params.config_mqc)
+    MULTIQC(params.input_file, params.config_mqc, params.outdir)
 }
 
 process MULTIQC {
-    container 'biocontainers/multiqc:1.25--pyhdfd78af_0'
+    container 'biocontainers/multiqc:1.27.1--pyhdfd78af_0'
 
     input:
-    path runDirectory
+    path fileList
     path multiqcConfig
+    val outdir
 
     output:
     path("*")
 
     def isoDate = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    publishDir {"${params.outdir}" }, mode: params.publish_dir_mode, pattern: "multiqc_general_stats.csv", saveAs: { "${isoDate}.csv" }
+    publishDir {"${outdir}" }, mode: params.publish_dir_mode, pattern: "multiqc_general_stats.csv", saveAs: { "${isoDate}.csv" }
     
     script:
     def config = multiqcConfig ? "--config $multiqcConfig" : ''
     """
+    mkdir -p local_files
+
+    apt-get update && apt-get install -y awscli || yum install -y awscli
+
+    while IFS= read -r line; do d=\${line%/}; dir=\${d##*/} 
+        aws s3 cp "\$line" "local_files/\$dir" --recursive
+    done < $fileList
+
+    # Create a new file list with local paths
+    find local_files -mindepth 1 -maxdepth 1 -type d > local_file_list.txt
+
+    # Run MultiQC
     multiqc ${config} \
-        --data-dir \
+        --file-list local_file_list.txt \
         --data-format csv \
         --no-report \
+        --dirs \
         --force \
-        ${runDirectory}
-    mv multiqc_data/* .
+        -o multiqc_output
+    mv multiqc_output/multiqc_data/* .
     """
 }


### PR DESCRIPTION
Input parameter changed to a list with s3 path. Example:
$cat input_lists
s3://bucket/mqc/$repoID_$runName
s3://bucket/mqc/$repoID2_$runName

For the output, directory path will be in the 'Sample' column. Example:
Illumina:
/ | tmp | nxf.vUaooJtZmQ | local_files | $repoid_$uuid | $repoid | $repoid

MGI:
/ | tmp | nxf.OftRa65iGz | local_files | $repoid_$uuid | $repoid
